### PR TITLE
Add format to MainCount Number

### DIFF
--- a/src/components/MainCounts.js
+++ b/src/components/MainCounts.js
@@ -28,12 +28,12 @@ export default class MainCounts extends Component {
 
                         return (
                             <div key={`${metric}-number`} className="count-wrap">
-                                <div className="count">{count ? count : 0}</div>
+                                <div className="count">{count ? count.toLocaleString() : 0}</div>
                                 <div className="count-title">{metricText[metric][lang]}</div>
                                 <div className="count-daily">
                                     {diff != null &&
                                     !isNaN(diff) && (
-                                        <span>{`${i18n.NEWCASE[lang]} ${diff >= 0 ? '+' : ''}${diff}`}</span>
+                                        <span>{`${i18n.NEWCASE[lang]} ${diff >= 0 ? '+' : ''}${diff.toLocaleString()}`}</span>
                                     )}
                                 </div>
                             </div>


### PR DESCRIPTION
This adds format to the numbers in the `MainCount` component.

Sadly the numbers of COVID are getting larger and it is easier to track by adding "," (commas) to the number.

<img width="390" alt="Screen Shot 2020-04-14 at 10 01 56 PM" src="https://user-images.githubusercontent.com/327827/79287994-d9f58b80-7e9b-11ea-88f1-1f5490d42342.png">
