### PR TITLE
fixing flag code/display flag for ireland

### DIFF
--- a/src/utils/map_text.js
+++ b/src/utils/map_text.js
@@ -197,7 +197,7 @@ export const mapText = {
     IRL: {
         title: i18n.IRELAND_MAP,
         regionName: str.IRELAND_ZH,
-        flagCode: 'ir',
+        flagCode: 'ie',
         continent: i18n.EUROPE
     },
     CZE: {


### PR DESCRIPTION
This is just an issue in the HTML for that dropdown. The flag pack the project uses is flag-icon-css, this uses https://www.iso.org/obp/ui/#search to get country 2 letter identifiers for the various flags. If you inspect the Irish flag in the running app "flag-icon-ir" (which is for Iran) is used instead of "flag-icon-ie" (Ireland).