### PR TITLE
Change YachayData for MapaCovid

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Pull requests are welcome. If you'd like to support the work and buy me a ☕, I
 - Switzerland: [daenuprobst/covid19-cases-switzerland](https://github.com/daenuprobst/covid19-cases-switzerland)
 - United Kingdom: [tomwhite/covid-19-uk-data](https://github.com/tomwhite/covid-19-uk-data)
 - Iran/Hungary: [Wikipedia](https://en.wikipedia.org/wiki/Template:2019%E2%80%9320_coronavirus_pandemic_data)
-- Chile: [YachayData/COVID-19](https://github.com/YachayData/COVID-19)
+- Chile: [MapaCovid/COVID-19](https://github.com/MapaCovid/COVID-19)
 - Portugal: [Dados relativos à pandemia COVID-19 em Portugal](https://github.com/dssg-pt/covid19pt-data)
 - Brazil: [COVID-19 Brazil - time series data](https://github.com/elhenrico/covid19-Brazil-timeseries)
 - Malaysia: [ynshung/covid-19-malaysia](https://github.com/ynshung/covid-19-malaysia)


### PR DESCRIPTION
Hi Steven! We changed the name of the organization, for the data in Chile, so the repository is now in 
https://github.com/MapaCovid/COVID-19/